### PR TITLE
Added the executable path for sphinx-build on Linux

### DIFF
--- a/en/Makefile
+++ b/en/Makefile
@@ -5,6 +5,8 @@
 SPHINXOPTS    =
 ifeq ($(UNAME),Darwin)
 	SPHINXBUILD   = sphinx-build
+else if ($(UNAME),Linux)
+	SPHINXBUILD = sphinx-build
 else
 	SPHINXBUILD   = /usr/lib/python-exec/python2.7/sphinx-build
 endif

--- a/ru/Makefile
+++ b/ru/Makefile
@@ -5,6 +5,8 @@
 SPHINXOPTS    =
 ifeq ($(UNAME),Darwin)
 	SPHINXBUILD   = sphinx-build
+else if ($(UNAME),Linux)
+	SPHINXBUILD = sphinx-build
 else
 	SPHINXBUILD   = /usr/lib/python-exec/python2.7/sphinx-build
 endif


### PR DESCRIPTION
Hi Romans,

As an exercise I made the smallest possible change in the Books repository. The Book would not compile on Linux because sphinx-build is located in /usr/bin/. Just like on the Mac.

It is the first time I am using git, github and everything hence the exercise and the tiny change in its own branch.

The problem of course is that the sphinx-build location might not be valid for _all_ Linuces. At least it is for Debian and friends.

Kind regards
Hans
